### PR TITLE
Converted to bundler

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,4 +1,0 @@
-builder
-rdiscount
-toto
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org" 
+
+gem "builder" 
+gem "rdiscount" 
+gem "toto"

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+require 'bundler' 
+Bundler.setup
 
 require 'toto'
 


### PR DESCRIPTION
replaced the .gems file with a Gemfile for use with bundler. Heroku now supports bundler and relying on it with dorothy makes getting a local instance up and running as simple as "bundle install".

The .gems manifest has been deprecated by Heroku.
